### PR TITLE
Updated information about the place to clone this repository or to download an archived snapshot.

### DIFF
--- a/AndroidWearMap/README.md
+++ b/AndroidWearMap/README.md
@@ -20,7 +20,7 @@ Getting Started
 This sample use the Gradle build system.
 
 First download the samples by cloning this repository or downloading an archived
-snapshot. (See the options on the right hand side.)
+snapshot. (See the options at the top of the page.)
 
 In Android Studio, use the "Import non-Android Studio project" or 
 "Import Project" option. Next select the ApiDemos/ directory that you downloaded

--- a/ApiDemos/README.md
+++ b/ApiDemos/README.md
@@ -21,7 +21,7 @@ Getting Started
 This sample use the Gradle build system.
 
 First download the samples by cloning this repository or downloading an archived
-snapshot. (See the options on the right hand side.)
+snapshot. (See the options at the top of the page.)
 
 In Android Studio, use the "Import non-Android Studio project" or 
 "Import Project" option. Next select the ApiDemos/ directory that you downloaded

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Getting Started
 These samples use the Gradle build system.
 
 First download the samples by cloning this repository or downloading an archived
-snapshot. (See the options on the right hand side.)
+snapshot. (See the options at the top of the page.)
 
 In Android Studio, use the "Import non-Android Studio project" or 
 "Import Project" option. Next select one of the sample directories that you downloaded from this


### PR DESCRIPTION
Now, these options (to clone a repository or download an archived snapshot) are at the top of page, because [Github changed the repositories' layout](https://github.com/blog/2085-a-new-look-for-repositories). 