### PR TITLE
fix: issue 53 'Permission request infinite loop'

### DIFF
--- a/tutorials/CurrentPlaceDetailsOnMap/app/src/main/java/com/example/currentplacedetailsonmap/MapsActivityCurrentPlace.java
+++ b/tutorials/CurrentPlaceDetailsOnMap/app/src/main/java/com/example/currentplacedetailsonmap/MapsActivityCurrentPlace.java
@@ -258,10 +258,10 @@ public class MapsActivityCurrentPlace extends AppCompatActivity
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
                     mLocationPermissionGranted = true;
+                    updateLocationUI();
                 }
             }
         }
-        updateLocationUI();
     }
 
     /**


### PR DESCRIPTION
possible fix for #53:
I could reproduce this error, too.
My solution was placing the `updateLocationUI();` into the if-branch so it'll only be executed (and the location UI updated) again if the user accepts the permission request. Otherwise it tries to refresh the location (and the permission request) without any (positive) permission result again and again which causes the loop.