### PR TITLE
docs: Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/googlemaps/android-samples)
-![Apache-2.0](https://img.shields.io/badge/license-Apache-blue) ![[Build demos](https://github.com/googlemaps/android-samples/workflows/Build%20demos/badge.svg)](https://github.com/googlemaps/android-samples/actions?query=workflow%3A%22Build+demos%22)
+![Apache-2.0](https://img.shields.io/badge/license-Apache-blue) [![Build demos](https://github.com/googlemaps/android-samples/workflows/Build%20demos/badge.svg)](https://github.com/googlemaps/android-samples/actions?query=workflow%3A%22Build+demos%22)
 
 Google Maps SDK for Android Samples
 ===================================

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![GitHub contributors](https://img.shields.io/github/contributors/googlemaps/android-samples)
-![Apache-2.0](https://img.shields.io/badge/license-Apache-blue)
+![Apache-2.0](https://img.shields.io/badge/license-Apache-blue) ![[Build demos](https://github.com/googlemaps/android-samples/workflows/Build%20demos/badge.svg)](https://github.com/googlemaps/android-samples/actions?query=workflow%3A%22Build+demos%22)
 
 Google Maps SDK for Android Samples
 ===================================


### PR DESCRIPTION
Adds a CI badge to the README file that links to the GitHub CI builds:

![image](https://user-images.githubusercontent.com/928045/81230317-422d1e00-8fbf-11ea-9746-15dfcb516f01.png)
