### PR TITLE
chore: Remove KTX from basic map demo

### DIFF
--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -48,12 +48,6 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'com.android.support.constraint:constraint-layout:1.1.3'
 
-    // Google Maps KTX extensions
-    implementation 'com.google.maps.android:maps-ktx:1.4.0'
-
-    // Needed for coroutines
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.2.0'
-
     // Below is used to run the easypermissions library to manage location permissions
     // EasyPermissions is needed to help us request for permission to access location
     implementation 'pub.devrel:easypermissions:3.0.0'

--- a/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/BasicMapDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/BasicMapDemoActivity.kt
@@ -18,38 +18,36 @@ package com.example.kotlindemos
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import androidx.lifecycle.coroutineScope
-import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
-import com.google.android.gms.maps.model.MarkerOptions
-import com.google.maps.android.ktx.MapsExperimentalFeature
-import com.google.maps.android.ktx.awaitMap
 
 /**
  * This shows how to create a simple activity with a map and a marker on the map.
  */
 class BasicMapDemoActivity :
-        AppCompatActivity() {
+        AppCompatActivity(),
+        OnMapReadyCallback {
 
     val SYDNEY = LatLng(-33.862, 151.21)
     val ZOOM_LEVEL = 13f
 
-    @MapsExperimentalFeature
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_basic_map_demo)
-        val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as? SupportMapFragment
+        val mapFragment : SupportMapFragment? =
+                supportFragmentManager.findFragmentById(R.id.map) as? SupportMapFragment
+        mapFragment?.getMapAsync(this)
+    }
 
-        lifecycle.coroutineScope.launchWhenCreated {
-            check(mapFragment != null)
-            val googleMap = mapFragment.awaitMap() // Execution pauses here until we get the callback from the Maps SDK with a googleMap.
-            // This is where we can add markers or lines, add listeners or move the camera.
-            // In this case, we just move the camera to Sydney and add a marker in Sydney.
-            with(googleMap) {
-                moveCamera(CameraUpdateFactory.newLatLngZoom(SYDNEY, ZOOM_LEVEL))
-                addMarker(MarkerOptions().position(SYDNEY))
-            }
+    /**
+     * This is where we can add markers or lines, add listeners or move the camera. In this case,
+     * we just move the camera to Sydney and add a marker in Sydney.
+     */
+    override fun onMapReady(googleMap: GoogleMap?) {
+        googleMap ?: return
+        with(googleMap) {
+            moveCamera(CameraUpdateFactory.newLatLngZoom(SYDNEY, ZOOM_LEVEL))
+            addMarker(MarkerOptions().position(SYDNEY))
         }
     }
 }

--- a/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/BasicMapDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/BasicMapDemoActivity.kt
@@ -18,15 +18,19 @@ package com.example.kotlindemos
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
+import com.google.android.gms.maps.CameraUpdateFactory
+import com.google.android.gms.maps.GoogleMap
+import com.google.android.gms.maps.OnMapReadyCallback
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
 
 /**
  * This shows how to create a simple activity with a map and a marker on the map.
  */
 class BasicMapDemoActivity :
         AppCompatActivity(),
-        OnMapReadyCallback {
+    OnMapReadyCallback {
 
     val SYDNEY = LatLng(-33.862, 151.21)
     val ZOOM_LEVEL = 13f

--- a/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/BasicMapDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/main/java/com/example/kotlindemos/BasicMapDemoActivity.kt
@@ -22,8 +22,8 @@ import androidx.lifecycle.coroutineScope
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.SupportMapFragment
 import com.google.android.gms.maps.model.LatLng
+import com.google.android.gms.maps.model.MarkerOptions
 import com.google.maps.android.ktx.MapsExperimentalFeature
-import com.google.maps.android.ktx.addMarker
 import com.google.maps.android.ktx.awaitMap
 
 /**
@@ -42,14 +42,13 @@ class BasicMapDemoActivity :
         val mapFragment = supportFragmentManager.findFragmentById(R.id.map) as? SupportMapFragment
 
         lifecycle.coroutineScope.launchWhenCreated {
-            val googleMap = mapFragment?.awaitMap() // Execution pauses here until we get the callback from the Maps SDK with a googleMap.
+            check(mapFragment != null)
+            val googleMap = mapFragment.awaitMap() // Execution pauses here until we get the callback from the Maps SDK with a googleMap.
             // This is where we can add markers or lines, add listeners or move the camera.
             // In this case, we just move the camera to Sydney and add a marker in Sydney.
             with(googleMap) {
-                this?.moveCamera(CameraUpdateFactory.newLatLngZoom(SYDNEY, ZOOM_LEVEL))
-                this?.addMarker {
-                    position(SYDNEY)
-                }
+                moveCamera(CameraUpdateFactory.newLatLngZoom(SYDNEY, ZOOM_LEVEL))
+                addMarker(MarkerOptions().position(SYDNEY))
             }
         }
     }


### PR DESCRIPTION
This pull request reverts https://github.com/googlemaps/android-samples/pull/193 and https://github.com/googlemaps/android-samples/pull/188 to remove KTX from the basic map demo.

Per further discussion we're going to have these samples be pure Kotlin implementations without KTX.