### PR TITLE
chore: Remove 'silent' from END_EXCLUDE tags

### DIFF
--- a/tutorials/java/MapWithMarker/app/src/main/java/com/example/mapwithmarker/MapsMarkerActivity.java
+++ b/tutorials/java/MapWithMarker/app/src/main/java/com/example/mapwithmarker/MapsMarkerActivity.java
@@ -57,7 +57,7 @@ public class MapsMarkerActivity extends AppCompatActivity
      * Play services inside the SupportMapFragment. The API invokes this method after the user has
      * installed Google Play services and returned to the app.
      */
-    // [END_EXCLUDE silent]
+    // [END_EXCLUDE]
     @Override
     public void onMapReady(GoogleMap googleMap) {
         // Add a marker in Sydney, Australia,

--- a/tutorials/java/Polygons/app/src/main/java/com/example/polygons/PolyActivity.java
+++ b/tutorials/java/Polygons/app/src/main/java/com/example/polygons/PolyActivity.java
@@ -132,7 +132,7 @@ public class PolyActivity extends AppCompatActivity
                         new LatLng(-12.4258, 130.7932)));
         polygon2.setTag("beta");
         stylePolygon(polygon2);
-        // [END_EXCLUDE silent]
+        // [END_EXCLUDE]
 
         // Position the map's camera near Alice Springs in the center of Australia,
         // and set the zoom factor so most of Australia shows on the screen.

--- a/tutorials/kotlin/Polygons/app/src/main/java/com/example/polygons/PolyActivity.kt
+++ b/tutorials/kotlin/Polygons/app/src/main/java/com/example/polygons/PolyActivity.kt
@@ -124,7 +124,7 @@ class PolyActivity : AppCompatActivity(), OnMapReadyCallback, OnPolylineClickLis
                 LatLng(-12.4258, 130.7932)))
         polygon2.tag = "beta"
         stylePolygon(polygon2)
-        // [END_EXCLUDE silent]
+        // [END_EXCLUDE]
 
         // Position the map's camera near Alice Springs in the center of Australia,
         // and set the zoom factor so most of Australia shows on the screen.


### PR DESCRIPTION
[END_EXCLUDE] w/o `silent` is the proper way to escape [START_EXCLUDE silent]
