### PR TITLE
feat: Target API level 30.

### DIFF
--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -4,12 +4,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'project-report'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
     defaultConfig {
         applicationId "com.example.mapdemo"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/ApiDemos/java/app/src/gms/java/com/example/mapdemo/BasicMapDemoActivity.java
+++ b/ApiDemos/java/app/src/gms/java/com/example/mapdemo/BasicMapDemoActivity.java
@@ -14,10 +14,14 @@
 
 package com.example.mapdemo;
 
+import android.content.Intent;
+import android.net.Uri;
 import com.google.android.gms.maps.GoogleMap;
+import com.google.android.gms.maps.GoogleMap.OnMarkerClickListener;
 import com.google.android.gms.maps.OnMapReadyCallback;
 import com.google.android.gms.maps.SupportMapFragment;
 import com.google.android.gms.maps.model.LatLng;
+import com.google.android.gms.maps.model.Marker;
 import com.google.android.gms.maps.model.MarkerOptions;
 
 import android.os.Bundle;

--- a/ApiDemos/java/app/src/gms/java/com/example/mapdemo/DemoDetailsList.java
+++ b/ApiDemos/java/app/src/gms/java/com/example/mapdemo/DemoDetailsList.java
@@ -15,6 +15,8 @@
 
 package com.example.mapdemo;
 
+import com.example.mapdemo.polyline.PolylineDemoActivity;
+
 /**
  * A list of all the demos we have available.
  */

--- a/ApiDemos/java/app/src/gms/java/com/example/mapdemo/polyline/PolylineDemoActivity.java
+++ b/ApiDemos/java/app/src/gms/java/com/example/mapdemo/polyline/PolylineDemoActivity.java
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 
-package com.example.mapdemo;
+package com.example.mapdemo.polyline;
 
 import android.graphics.Color;
 import android.os.Bundle;
@@ -28,6 +28,7 @@ import android.widget.Spinner;
 
 import androidx.appcompat.app.AppCompatActivity;
 
+import com.example.mapdemo.R;
 import com.google.android.gms.maps.CameraUpdateFactory;
 import com.google.android.gms.maps.GoogleMap;
 import com.google.android.gms.maps.OnMapReadyCallback;

--- a/ApiDemos/java/app/src/main/AndroidManifest.xml
+++ b/ApiDemos/java/app/src/main/AndroidManifest.xml
@@ -17,6 +17,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.mapdemo">
 
+    <queries>
+        <package android:name="com.google.android.apps.maps" />
+    </queries>
+
     <!--
          The ACCESS_COARSE/FINE_LOCATION permissions are not required to use
          Google Maps Android API v2, but you must specify either coarse or fine

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -5,11 +5,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.example.kotlindemos"
         minSdkVersion 16
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/LiteListDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/LiteListDemoActivity.kt
@@ -86,8 +86,8 @@ class LiteListDemoActivity : AppCompatActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        recyclerView.layoutManager = when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        recyclerView.layoutManager = when (item.itemId) {
             R.id.layout_linear -> linearLayoutManager
             R.id.layout_grid -> gridLayoutManager
             else -> return false

--- a/ApiDemos/kotlin/app/src/main/AndroidManifest.xml
+++ b/ApiDemos/kotlin/app/src/main/AndroidManifest.xml
@@ -16,6 +16,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.example.kotlindemos">
 
+    <queries>
+        <package android:name="com.google.android.apps.maps" />
+    </queries>
+
     <!-- This app requires location permissions for the layers demo.
     The user's current location is displayed using the 'My Location' layer. -->
     <!-- Access to location is needed for the UI Settings Demo -->

--- a/ApiDemos/kotlin/app/src/v3/java/com/example/kotlindemos/LiteListDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/v3/java/com/example/kotlindemos/LiteListDemoActivity.kt
@@ -93,8 +93,8 @@ class LiteListDemoActivity : AppCompatActivity() {
         return true
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        recyclerView.layoutManager = when (item?.itemId) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        recyclerView.layoutManager = when (item.itemId) {
             R.id.layout_linear -> linearLayoutManager
             R.id.layout_grid -> gridLayoutManager
             else -> return false


### PR DESCRIPTION
Updates target SDK version to API level 30. Other changes:
* explicit query to open Google Maps app. This is necessary so that buttons on the [map toolbar UI](https://developers.google.com/maps/documentation/android-sdk/controls) work. Otherwise, an error saying 'Google Maps is not installed or is disabled' will appear as pointed out in #371. This change is necessary as per package visibility changes introduced in Android 11.
* Fix `AndroidManifest.xml` reference to `PolylineDemoActivity` for the `gmsDebug` gradle variant.

Fixes #371 🦕
