### PR TITLE
chore: Remove queries entry.

### DIFF
--- a/ApiDemos/java/app/src/main/AndroidManifest.xml
+++ b/ApiDemos/java/app/src/main/AndroidManifest.xml
@@ -18,17 +18,6 @@
     package="com.example.mapdemo">
 
     <!--
-        Android 11 package visibility changes require that apps specify which
-        set of other packages on the device that they can access. Since this
-        sample uses Google Maps, specifying the Google Maps package name is
-        required so that the buttons on the Map toolbar launch the Google Maps
-        app.
-    -->
-    <queries>
-        <package android:name="com.google.android.apps.maps" />
-    </queries>
-
-    <!--
          The ACCESS_COARSE/FINE_LOCATION permissions are not required to use
          Google Maps Android API v2, but you must specify either coarse or fine
          location permissions for the 'MyLocation' functionality.

--- a/ApiDemos/kotlin/app/src/main/AndroidManifest.xml
+++ b/ApiDemos/kotlin/app/src/main/AndroidManifest.xml
@@ -17,17 +17,6 @@
     package="com.example.kotlindemos">
 
     <!--
-        Android 11 package visibility changes require that apps specify which
-        set of other packages on the device that they can access. Since this
-        sample uses Google Maps, specifying the Google Maps package name is
-        required so that the buttons on the Map toolbar launch the Google Maps
-        app.
-    -->
-    <queries>
-        <package android:name="com.google.android.apps.maps" />
-    </queries>
-
-    <!--
         This app requires location permissions for the layers demo.
         The user's current location is displayed using the 'My Location' layer.
         Access to location is needed for the UI Settings Demo


### PR DESCRIPTION
Removing queries entry as this is no longer needed in version 17.0.1. See [release notes](https://developers.google.com/maps/documentation/android-sdk/releases#april_27_2021).
