### PR TITLE
chore: Update to secrets-gradle-plugin 1.2.0

### DIFF
--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -3,7 +3,7 @@ import org.apache.tools.ant.filters.ConcatFilter
 plugins {
     id 'com.android.application'
     id 'project-report'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/ApiDemos/java/build.gradle
+++ b/ApiDemos/java/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/ApiDemos/kotlin/build.gradle
+++ b/ApiDemos/kotlin/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     // [START maps_android_secrets_gradle_plugin]
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
     // [END maps_android_secrets_gradle_plugin]
 }
 

--- a/snippets/build.gradle
+++ b/snippets/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/snippets/build.gradle
+++ b/snippets/build.gradle
@@ -1,19 +1,24 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
+// [START maps_android_secrets_gradle_plugin_classpath]
 buildscript {
+    // [START_EXCLUDE silent]
     ext.kotlin_version = "1.5.10"
     repositories {
         google()
         jcenter()
     }
+    // [END_EXCLUDE]
     dependencies {
+        // [START_EXCLUDE]
         classpath "com.android.tools.build:gradle:4.1.3"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
-
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
+        // [END_EXCLUDE]
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
     }
 }
+// [END maps_android_secrets_gradle_plugin_classpath]
 
 allprojects {
     repositories {

--- a/tutorials/java/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/tutorials/java/CurrentPlaceDetailsOnMap/build.gradle
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
-
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/tutorials/java/MapWithMarker/app/build.gradle
+++ b/tutorials/java/MapWithMarker/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/tutorials/java/MapWithMarker/build.gradle
+++ b/tutorials/java/MapWithMarker/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tutorials/java/Polygons/app/build.gradle
+++ b/tutorials/java/Polygons/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.android.application'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/tutorials/java/Polygons/build.gradle
+++ b/tutorials/java/Polygons/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tutorials/java/StyledMap/build.gradle
+++ b/tutorials/java/StyledMap/build.gradle
@@ -7,6 +7,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.2'
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/build.gradle
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/tutorials/kotlin/MapWithMarker/app/build.gradle
+++ b/tutorials/kotlin/MapWithMarker/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/tutorials/kotlin/MapWithMarker/build.gradle
+++ b/tutorials/kotlin/MapWithMarker/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/tutorials/kotlin/Polygons/app/build.gradle
+++ b/tutorials/kotlin/Polygons/app/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'com.android.application'
     id 'kotlin-android'
     id 'kotlin-android-extensions'
-    id 'com.google.android.secrets-gradle-plugin' version '1.1.0'
+    id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin'
 }
 
 android {

--- a/tutorials/kotlin/Polygons/build.gradle
+++ b/tutorials/kotlin/Polygons/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:1.2.0"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Update to secrets-gradle-plugin 1.2.0 which has a new maven coordinate located with google maven. See the secrets-gradle-plugin [README](https://github.com/google/secrets-gradle-plugin#installation) installation instructions to learn more.
