### PR TITLE
fix: force close in the camera demo activity

### DIFF
--- a/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/CameraDemoActivity.kt
+++ b/ApiDemos/kotlin/app/src/gms/java/com/example/kotlindemos/CameraDemoActivity.kt
@@ -104,6 +104,7 @@ class CameraDemoActivity :
     // [END_EXCLUDE]
 
     override fun onMapReady(googleMap: GoogleMap) {
+        map = googleMap
         // return early if the map was not initialised properly
         with(googleMap) {
             setOnCameraIdleListener(this@CameraDemoActivity)


### PR DESCRIPTION
map object was not initialized, and it caused a crash in the sample app. Logs in #795