### PR TITLE
fix: revert dependencies to last green build

### DIFF
--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -57,7 +57,7 @@ dependencies {
     // GMS
     gmsImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
     gmsImplementation 'com.google.android.gms:play-services-maps:18.0.2'
-    gmsImplementation 'com.google.maps.android:maps-ktx:3.4.0'
+    gmsImplementation 'com.google.maps.android:maps-ktx:3.3.0'
 
     // V3
     v3Implementation 'com.google.android.libraries.maps:maps:3.1.0-beta'

--- a/ApiDemos/kotlin/build.gradle
+++ b/ApiDemos/kotlin/build.gradle
@@ -1,13 +1,13 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.1.3'
+        classpath 'com.android.tools.build:gradle:7.1.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "com.google.android.libraries.mapsplatform.secrets-gradle-plugin:secrets-gradle-plugin:2.0.1"
 

--- a/WearOS/Wearable/build.gradle
+++ b/WearOS/Wearable/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     // [START_EXCLUDE]
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation "androidx.core:core-ktx:1.7.0"
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.21'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.6.10'
     // [END_EXCLUDE]
     compileOnly 'com.google.android.wearable:wearable:2.9.0'
     implementation 'com.google.android.support:wearable:2.9.0'

--- a/WearOS/build.gradle
+++ b/WearOS/build.gradle
@@ -17,5 +17,5 @@
 plugins {
     id 'com.android.application' version '7.1.2' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
 }

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -54,7 +54,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.21'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.6.10'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation "androidx.compose.foundation:foundation:1.2.0-alpha06"
@@ -68,8 +68,8 @@ dependencies {
     implementation 'io.reactivex.rxjava3:rxjava:3.1.4'
     implementation 'com.google.android.libraries.places:places:2.5.0'
 
-    gmsImplementation 'com.google.maps.android:maps-ktx:3.4.0'
-    gmsImplementation 'com.google.maps.android:maps-compose:2.1.1'
+    gmsImplementation 'com.google.maps.android:maps-ktx:3.3.0'
+    gmsImplementation 'com.google.maps.android:maps-compose:2.0.0'
     gmsImplementation 'com.google.android.gms:play-services-maps:18.0.2'
     gmsImplementation 'com.google.maps.android:android-maps-utils:2.3.0'
     gmsImplementation 'com.google.maps.android:maps-rx:1.0.0'

--- a/snippets/build.gradle
+++ b/snippets/build.gradle
@@ -2,7 +2,7 @@
 plugins {
     // [START_EXCLUDE]
     id 'com.android.application' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.6.21' apply false
+    id 'org.jetbrains.kotlin.android' version '1.6.10' apply false
     // [END_EXCLUDE]
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
 }

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     })
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'com.google.android.gms:play-services-maps:18.0.2'
-    implementation 'com.google.android.libraries.places:places:2.6.0'
+    implementation 'com.google.android.libraries.places:places:2.5.0'
     implementation 'com.android.volley:volley:1.2.1'
     testImplementation'junit:junit:4.13'
     implementation "androidx.core:core-ktx:1.7.0"

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/build.gradle
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         mavenCentral()
         google()

--- a/tutorials/kotlin/MapWithMarker/build.gradle
+++ b/tutorials/kotlin/MapWithMarker/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         google()
         mavenCentral()

--- a/tutorials/kotlin/Polygons/build.gradle
+++ b/tutorials/kotlin/Polygons/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.6.10'
     repositories {
         mavenCentral()
         google()


### PR DESCRIPTION
Reverting dependencies back to https://github.com/googlemaps/android-samples/commit/0ec4153b3766bc2fcecb0e2b638971544325aa87 from earlier April.