### PR TITLE
build: add test status check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,3 +115,13 @@ jobs:
           done
           cd ..
         done
+
+  test: # used as required status check
+    runs-on: ubuntu-latest
+    needs:
+      - build-ApiDemos
+      - build-WearOS
+      - build-Snippets
+      - build-tutorials
+    steps: 
+      - run: echo "Fail if all other steps are not successful"


### PR DESCRIPTION
This adds a summary status check that can be used as required branch protection rule.