### PR TITLE
chore: Add maps-compose library region tags

### DIFF
--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -25,7 +25,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0-beta03'
+        kotlinCompilerExtensionVersion '1.2.0-alpha05'
     }
 
     buildFeatures {
@@ -59,8 +59,8 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.7.0'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.compose.foundation:foundation:1.2.0-beta03"
-    implementation "androidx.compose.material:material:1.2.0-beta03"
+    implementation "androidx.compose.foundation:foundation:1.2.0-alpha05"
+    implementation "androidx.compose.material:material:1.2.0-alpha05"
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -25,7 +25,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0-alpha05'
+        kotlinCompilerExtensionVersion '1.2.0-beta03'
     }
 
     buildFeatures {
@@ -52,13 +52,15 @@ android {
     }
 }
 
+// [START maps_android_compose_dependency]
 dependencies {
+    // [START_EXCLUDE silent]
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.7.0'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.compose.foundation:foundation:1.2.0-alpha06"
-    implementation "androidx.compose.material:material:1.2.0-alpha06"
+    implementation "androidx.compose.foundation:foundation:1.2.0-beta03"
+    implementation "androidx.compose.material:material:1.2.0-beta03"
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
@@ -77,7 +79,12 @@ dependencies {
     v3Implementation 'com.google.android.libraries.maps:maps:3.1.0-beta'
 
     testImplementation 'junit:junit:4.13.2'
+
+    // [END_EXCLUDE]
+    implementation 'com.google.maps.android:maps-compose:2.2.1'
+    implementation 'com.google.android.gms:play-services-maps:18.0.2'
 }
+// [END maps_android_compose_dependency]
 
 // [START maps_android_secrets_gradle_plugin_config]
 secrets {

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -25,7 +25,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0-alpha05'
+        kotlinCompilerExtensionVersion '1.2.0-alpha06'
     }
 
     buildFeatures {

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -59,8 +59,8 @@ dependencies {
     implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.7.0'
     implementation 'androidx.core:core-ktx:1.7.0'
     implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.compose.foundation:foundation:1.2.0-alpha05"
-    implementation "androidx.compose.material:material:1.2.0-alpha05"
+    implementation "androidx.compose.foundation:foundation:1.2.0-alpha06"
+    implementation "androidx.compose.material:material:1.2.0-alpha06"
     implementation 'com.google.android.material:material:1.5.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
     implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'


### PR DESCRIPTION
As discussed in https://github.com/googlemaps/android-maps-compose/pull/148#issuecomment-1156791458, this PR migrates the region tags for the maps-compose library version from the demo app in that repo to the snippets app in this repo.

---

Before submitting your PR, there are a few things you can do to make sure it goes smoothly:
- [x] Make sure to open a GitHub issue as a bug/feature request before writing your code!  That way we can discuss the change, evaluate designs, and agree on the general idea
- [x] Ensure the tests and linter pass
- [x] Code coverage does not decrease (if any source code was changed)
- [x] Appropriate docs were updated (if necessary)
