### PR TITLE
chore(dependencies): general update of dependencies

### DIFF
--- a/ApiDemos/java/README.md
+++ b/ApiDemos/java/README.md
@@ -15,9 +15,8 @@ Android Studio’s “Build Variants” toolbar options.
 Pre-requisites
 --------------
 
-- Android SDK v30
+- Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 - Google Repository
 - Google Play Services
 

--- a/ApiDemos/java/app/build.gradle
+++ b/ApiDemos/java/app/build.gradle
@@ -7,12 +7,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     defaultConfig {
         applicationId "com.example.mapdemo"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         multiDexEnabled true

--- a/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/java/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/ApiDemos/kotlin/README.md
+++ b/ApiDemos/kotlin/README.md
@@ -15,9 +15,8 @@ Android Studio’s “Build Variants” toolbar options.
 Pre-requisites
 --------------
 
-- Android SDK v30
+- Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 - Google Repository
 - Google Play Services
 

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -8,11 +8,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.kotlindemos"
-        minSdkVersion 19
-        targetSdkVersion 31
+        minSdkVersion 21
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/ApiDemos/kotlin/app/build.gradle
+++ b/ApiDemos/kotlin/app/build.gradle
@@ -11,7 +11,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.kotlindemos"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"

--- a/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/ApiDemos/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Jan 25 11:17:39 PST 2021
+#Sat Oct 29 00:59:00 CEST 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/WearOS/README.md
+++ b/WearOS/README.md
@@ -8,7 +8,7 @@ gradle-based Android Studio project that [supports ambient mode](https://develop
 Pre-requisites
 --------------
 
-- Android SDK v22
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 - Wear OS emulator or device

--- a/WearOS/README.md
+++ b/WearOS/README.md
@@ -8,9 +8,8 @@ gradle-based Android Studio project that [supports ambient mode](https://develop
 Pre-requisites
 --------------
 
-- Android SDK v23
+- Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 - Wear OS emulator or device
 
 Getting Started

--- a/WearOS/README.md
+++ b/WearOS/README.md
@@ -8,7 +8,7 @@ gradle-based Android Studio project that [supports ambient mode](https://develop
 Pre-requisites
 --------------
 
-- Android SDK v33
+- Android SDK v23
 - Latest Android Build Tools
 - Android Support Repository
 - Wear OS emulator or device

--- a/WearOS/README.md
+++ b/WearOS/README.md
@@ -8,7 +8,7 @@ gradle-based Android Studio project that [supports ambient mode](https://develop
 Pre-requisites
 --------------
 
-- Android SDK v33
+- Android SDK v31
 - Latest Android Build Tools
 - Wear OS emulator or device
 

--- a/WearOS/Wearable/build.gradle
+++ b/WearOS/Wearable/build.gradle
@@ -21,12 +21,12 @@ plugins {
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 33
+    compileSdk 31
 
     defaultConfig {
         applicationId "com.example.wearos"
         minSdk 23
-        targetSdk 33
+        targetSdk 31
         versionCode 1
         versionName "1.0"
     }

--- a/WearOS/Wearable/build.gradle
+++ b/WearOS/Wearable/build.gradle
@@ -21,12 +21,12 @@ plugins {
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.example.wearos"
         minSdk 23
-        targetSdk 31
+        targetSdk 33
         versionCode 1
         versionName "1.0"
     }
@@ -36,18 +36,19 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.example.wearosmap'
 }
 
 // [START maps_wear_os_dependencies]
 dependencies {
     // [START_EXCLUDE]
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation "androidx.core:core-ktx:1.7.0"
+    implementation "androidx.core:core-ktx:1.9.0"
     implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.7.22'
     // [END_EXCLUDE]
     compileOnly 'com.google.android.wearable:wearable:2.9.0'
     implementation 'com.google.android.support:wearable:2.9.0'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
 
     // This dependency is necessary for ambient mode
     implementation 'androidx.wear:wear:1.2.0'

--- a/WearOS/Wearable/build.gradle
+++ b/WearOS/Wearable/build.gradle
@@ -21,7 +21,7 @@ plugins {
 apply plugin: 'kotlin-android'
 
 android {
-    compileSdk 31
+    compileSdk 33
 
     defaultConfig {
         applicationId "com.example.wearos"

--- a/WearOS/Wearable/src/main/AndroidManifest.xml
+++ b/WearOS/Wearable/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
   limitations under the License.
   -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.wearosmap" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <!-- Mark this app as a Wear OS app. -->
     <uses-feature android:name="android.hardware.type.watch" />

--- a/WearOS/build.gradle
+++ b/WearOS/build.gradle
@@ -15,7 +15,7 @@
  */
 
 plugins {
-    id 'com.android.application' version '7.1.2' apply false
+    id 'com.android.application' version '7.3.1' apply false
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
     id 'org.jetbrains.kotlin.android' version '1.7.22' apply false
 }

--- a/WearOS/gradle/wrapper/gradle-wrapper.properties
+++ b/WearOS/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue Mar 22 15:50:30 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/snippets/app/build.gradle
+++ b/snippets/app/build.gradle
@@ -7,11 +7,11 @@ plugins {
 }
 
 android {
-    compileSdk 32
+    compileSdk 33
     defaultConfig {
         applicationId "com.google.maps.example"
         minSdk 24
-        targetSdk 32
+        targetSdk 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -25,7 +25,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.2.0-alpha06'
+        kotlinCompilerExtensionVersion '1.4.0-alpha02'
     }
 
     buildFeatures {
@@ -50,29 +50,29 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
+    namespace 'com.google.maps.example'
 }
 
 // [START maps_android_compose_dependency]
 dependencies {
     // [START_EXCLUDE silent]
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.7.22'
-    implementation 'androidx.core:core-ktx:1.7.0'
-    implementation 'androidx.appcompat:appcompat:1.4.1'
-    implementation "androidx.compose.foundation:foundation:1.2.0-alpha06"
-    implementation "androidx.compose.material:material:1.2.0-alpha06"
-    implementation 'com.google.android.material:material:1.5.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation 'androidx.navigation:navigation-fragment-ktx:2.4.1'
-    implementation 'androidx.navigation:navigation-ui-ktx:2.4.1'
+    implementation 'org.jetbrains.kotlin:kotlin-stdlib:1.7.21'
+    implementation 'androidx.core:core-ktx:1.9.0'
+    implementation 'androidx.appcompat:appcompat:1.5.1'
+    implementation "androidx.compose.foundation:foundation:1.4.0-alpha02"
+    implementation "androidx.compose.material:material:1.4.0-alpha02"
+    implementation 'com.google.android.material:material:1.7.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation 'androidx.navigation:navigation-fragment-ktx:2.5.3'
+    implementation 'androidx.navigation:navigation-ui-ktx:2.5.3'
     implementation 'com.android.volley:volley:1.2.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.4.1'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
     implementation 'io.reactivex.rxjava3:rxjava:3.1.4'
-    implementation 'com.google.android.libraries.places:places:2.5.0'
-
+    implementation 'com.google.android.libraries.places:places:2.7.0'
     gmsImplementation 'com.google.maps.android:maps-ktx:3.4.0'
     gmsImplementation 'com.google.maps.android:maps-compose:2.7.3'
-    gmsImplementation 'com.google.android.gms:play-services-maps:18.0.2'
+    gmsImplementation 'com.google.android.gms:play-services-maps:18.1.0'
     gmsImplementation 'com.google.maps.android:android-maps-utils:2.4.0'
     gmsImplementation 'com.google.maps.android:maps-rx:1.0.0'
     gmsImplementation 'com.google.maps.android:places-rx:1.0.0'
@@ -82,7 +82,7 @@ dependencies {
 
     // [END_EXCLUDE]
     implementation 'com.google.maps.android:maps-compose:2.7.2'
-    implementation 'com.google.android.gms:play-services-maps:18.0.2'
+    implementation 'com.google.android.gms:play-services-maps:18.1.0'
 }
 // [END maps_android_compose_dependency]
 

--- a/snippets/app/src/main/AndroidManifest.xml
+++ b/snippets/app/src/main/AndroidManifest.xml
@@ -14,8 +14,7 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.google.maps.example">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 

--- a/snippets/build.gradle
+++ b/snippets/build.gradle
@@ -1,8 +1,8 @@
 // [START maps_android_secrets_gradle_plugin_project_level_config]
 plugins {
     // [START_EXCLUDE]
-    id 'com.android.application' version '7.1.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.7.22' apply false
+    id 'com.android.application' version '7.3.1' apply false
+    id 'org.jetbrains.kotlin.android' version '1.7.21' apply false
     // [END_EXCLUDE]
     id 'com.google.android.libraries.mapsplatform.secrets-gradle-plugin' version '2.0.1' apply false
 }

--- a/snippets/gradle/wrapper/gradle-wrapper.properties
+++ b/snippets/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Mar 21 15:55:38 PDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/java/CurrentPlaceDetailsOnMap/README.md
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v31
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 - Google Repository

--- a/tutorials/java/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.currentplacedetailsonmap"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -33,7 +33,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
     implementation 'com.google.android.libraries.places:places:2.7.0'
     implementation 'com.android.volley:volley:1.2.1'
-    testImplementation'junit:junit:4.12'
+    testImplementation'junit:junit:4.13.2'
 }
 
 secrets {

--- a/tutorials/java/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -7,7 +7,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.currentplacedetailsonmap"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"
@@ -22,6 +22,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.example.currentplacedetailsonmap'
 }
 
 dependencies {

--- a/tutorials/java/CurrentPlaceDetailsOnMap/app/src/main/AndroidManifest.xml
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.currentplacedetailsonmap">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/tutorials/java/MapWithMarker/README.md
+++ b/tutorials/java/MapWithMarker/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v30
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 - Google Repository

--- a/tutorials/java/MapWithMarker/README.md
+++ b/tutorials/java/MapWithMarker/README.md
@@ -9,7 +9,6 @@ Prerequisites
 
 - Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 - Google Repository
 - Google Play Services
 

--- a/tutorials/java/MapWithMarker/app/build.gradle
+++ b/tutorials/java/MapWithMarker/app/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.mapwithmarker"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/tutorials/java/Polygons/README.md
+++ b/tutorials/java/Polygons/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v29
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 

--- a/tutorials/java/Polygons/README.md
+++ b/tutorials/java/Polygons/README.md
@@ -9,7 +9,6 @@ Prerequisites
 
 - Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 
 Getting started
 ---------------

--- a/tutorials/java/Polygons/app/build.gradle
+++ b/tutorials/java/Polygons/app/build.gradle
@@ -4,11 +4,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.polygons"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/tutorials/java/StyledMap/README.md
+++ b/tutorials/java/StyledMap/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v24
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 

--- a/tutorials/java/StyledMap/README.md
+++ b/tutorials/java/StyledMap/README.md
@@ -9,7 +9,6 @@ Prerequisites
 
 - Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 
 Getting started
 ---------------

--- a/tutorials/java/StyledMap/app/build.gradle
+++ b/tutorials/java/StyledMap/app/build.gradle
@@ -10,11 +10,11 @@ if (rootProject.file("local.properties").exists()) {
 def mapsApiKey = properties.getProperty("MAPS_API_KEY", "")
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.styledmap"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/tutorials/java/StyledMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/java/StyledMap/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/README.md
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v24
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/README.md
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/README.md
@@ -9,7 +9,6 @@ Prerequisites
 
 - Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 
 Getting started
 ---------------

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.currentplacedetailsonmap"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -34,7 +34,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-maps:18.1.0'
     implementation 'com.google.android.libraries.places:places:2.7.0'
     implementation 'com.android.volley:volley:1.2.1'
-    testImplementation'junit:junit:4.13'
+    testImplementation'junit:junit:4.13.2'
     implementation "androidx.core:core-ktx:1.9.0"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.currentplacedetailsonmap"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 33
         versionCode 1
         versionName "1.0"
@@ -23,6 +23,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    namespace 'com.example.currentplacedetailsonmap'
 }
 
 dependencies {

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/src/main/AndroidManifest.xml
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/app/src/main/AndroidManifest.xml
@@ -15,8 +15,7 @@
  limitations under the License.
 -->
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.currentplacedetailsonmap">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/CurrentPlaceDetailsOnMap/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 27 11:35:42 PST 2021
+#Sun Nov 27 16:25:55 CET 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/MapWithMarker/README.md
+++ b/tutorials/kotlin/MapWithMarker/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v30
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 - Google Repository

--- a/tutorials/kotlin/MapWithMarker/app/build.gradle
+++ b/tutorials/kotlin/MapWithMarker/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
-    buildToolsVersion "28.0.3"
+    compileSdkVersion 33
+    buildToolsVersion "30.0.3"
     defaultConfig {
         applicationId "com.example.mapwithmarker"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/MapWithMarker/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 23 16:40:57 PDT 2022
+#Sun Nov 27 16:28:40 CET 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/tutorials/kotlin/Polygons/README.md
+++ b/tutorials/kotlin/Polygons/README.md
@@ -7,7 +7,7 @@ This sample goes hand in hand with a tutorial for the Google Maps Android API:
 Prerequisites
 --------------
 
-- Android SDK v29
+- Android SDK v33
 - Latest Android Build Tools
 - Android Support Repository
 

--- a/tutorials/kotlin/Polygons/README.md
+++ b/tutorials/kotlin/Polygons/README.md
@@ -9,7 +9,6 @@ Prerequisites
 
 - Android SDK v33
 - Latest Android Build Tools
-- Android Support Repository
 
 Getting started
 ---------------

--- a/tutorials/kotlin/Polygons/app/build.gradle
+++ b/tutorials/kotlin/Polygons/app/build.gradle
@@ -5,11 +5,11 @@ plugins {
 }
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
     defaultConfig {
         applicationId "com.example.polygons"
         minSdkVersion 19
-        targetSdkVersion 31
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
+++ b/tutorials/kotlin/Polygons/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jan 27 11:41:00 PST 2021
+#Sun Nov 27 16:29:54 CET 2022
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The current Pull Request introduces a general update of dependencies, and supersedes all the existing dependabot PRs.

This PR affects the `tutorials`, `snippets`, and `Api Demos` and `WearOS` projects. Changes include:

- Increased compileSdkVersion.
- Increased targetSdkVersion.
- Moves namespace from AndroidManifest to the build.gradle file.
- Increases Gradle plugin version.
- General dependencies updated.
- Updated documentation
- This supersedes all the existing dependabot PRs: #1105, #1102, #1096, #980

Note: this does not update Kotlin to the latest version (1.7.22 the 9th of December 2022), since we are waiting for the Compose compiler to add support.