### PR TITLE
fix: fixed release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,12 @@ jobs:
         echo "Generating ApiDemos (Java) APKs"
         cd $GITHUB_WORKSPACE/ApiDemos/java
         ./gradlew assemble
-        cp ./app/build/outputs/apk/gms/debug/app-gms-debug.apk $GITHUB_WORKSPACE/ApiDemos-java-gms-debug.apk
+        cp ./app/build/outputs/apk/debug/app-debug.apk $GITHUB_WORKSPACE/ApiDemos-java-debug.apk
 
         echo "Generating Kotlin (Kotlin) APKs"
         cd $GITHUB_WORKSPACE/ApiDemos/kotlin
         ./gradlew assemble
-        cp ./app/build/outputs/apk/gms/debug/app-gms-debug.apk $GITHUB_WORKSPACE/ApiDemos-kotlin-gms-debug.apk
+        cp ./app/build/outputs/apk/debug/app-debug.apk $GITHUB_WORKSPACE/ApiDemos-kotlin-debug.apk
 
     - uses: actions/setup-node@v2
       with:

--- a/.releaserc
+++ b/.releaserc
@@ -16,9 +16,7 @@ plugins:
         - "./ApiDemos/kotlin/app/build.gradle.kts"
   - - "@semantic-release/github"
     - assets:
-        - "./ApiDemos-java-gms-debug.apk"
-        - "./ApiDemos-java-v3-debug.apk"
-        - "./ApiDemos-kotlin-gms-debug.apk"
-        - "./ApiDemos-kotlin-v3-debug.apk"
+        - "./ApiDemos-java-debug.apk"
+        - "./ApiDemos-kotlin-debug.apk"
 options:
   debug: true


### PR DESCRIPTION
The following PR fixes the release configuration. GMS is not present anymore in the app for the ApiDemos and hence not needed.