### PR TITLE
build: removed HTML extension from header check

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -27,7 +27,6 @@ sourceFileExtensions:
   - 'ts'
   - 'js'
   - 'java'
-
   - 'txt'
   - 'kt'
   - 'kts'


### PR DESCRIPTION
This PR removes the HTML extension from the header-check.