### PR TITLE
chore: modified CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,4 +14,4 @@
 
 # https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
 
-.github/ @googlemaps/admin
+.github/ @googlemaps/googlemaps-admin


### PR DESCRIPTION
This PR modifies the CODEOWNERS file to include the right group.

@dkhawk : I believe the  `@googlemaps/googlemaps-admin` needs to have access to this repo. Could you check it?