### PR TITLE
chore: updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ local.properties
 secrets.properties
 .DS_Store
 .java-version
+
+# This covers new IDEs, like Antigravity
+.vscode/
+**/bin/


### PR DESCRIPTION
The following PR updates our .gitignore to make it compatible with Antigravity.