### PR TITLE
chore: fixed README and build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2026 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,8 +23,6 @@ on:
     branches: [ '*' ]
   repository_dispatch:
     types: [ build ]
-  schedule:
-    - cron: '0 0 * * 1'
   workflow_dispatch:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -51,7 +49,7 @@ jobs:
           fi 
         done
         
-        
+
   build-WearOS:
     runs-on: ubuntu-latest
     timeout-minutes: 45

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 # Google Maps SDK for Android Samples
 
-<img src="images/screenshots.png" width="1024" />
+<img src="images/screenshots.png" width="1164" />
 
 ## Description
 
@@ -19,13 +19,13 @@ Samples demonstrating how to use
 This repo contains the following samples:
 
 1. [ApiDemos](ApiDemos): A collection of small demos showing most features of the Maps SDK for Android.
-1. [FireMarkers](FireMarkers): Demonstrates how to use Firebase Realtime Database to drive synchronized, live animations on a Google Map across multiple devices using a controller/agent architecture.
-1. [WearOS](WearOS):
+2. [FireMarkers](FireMarkers): Demonstrates how to use Firebase Realtime Database to drive synchronized, live animations on a Google Map across multiple devices using a controller/agent architecture.
+3. [WearOS](WearOS):
 Displays a map on a Wear OS device. This sample demonstrates the basic
 setup required for a gradle-based Android Studio project.
-1. [Tutorials](https://github.com/googlemaps/android-samples/tree/main/tutorials): Samples
+4. [Tutorials](https://github.com/googlemaps/android-samples/tree/main/tutorials): Samples
 associated with tutorials in the developer's guide. See each sample for a link to the associated guide.
-1. [Snippets](snippets): Snippets for code found in https://developers.google.com/maps/documentation/android-sdk
+5. [Snippets](snippets): Snippets for code found in https://developers.google.com/maps/documentation/android-sdk
 
 ## Requirements
 


### PR DESCRIPTION
The following PR fixes a couple of issues on the README file (wrong enumeration, wrong size for a file), and removes a cron in the build flow which was triggering it every week. It is enough if we test the builds during a PR, this might have been introduced when the dependabot PRs were being automatically merged.