### PR TITLE
build: added setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,9 @@ jobs:
         distribution: 'adopt'
         java-version: '21'
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+
     - name: Build and check
       run: |
         ./gradlew :ApiDemos:java-app:assembleDebug
@@ -60,6 +63,9 @@ jobs:
         distribution: 'adopt'
         java-version: '21'
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+
     - name: Build and check
       run: ./gradlew :WearOS:Wearable:assembleDebug
 
@@ -76,6 +82,9 @@ jobs:
         distribution: 'adopt'
         java-version: '21'
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+
     - name: Build and check
       run: ./gradlew :FireMarkers:app:assembleDebug
 
@@ -91,6 +100,9 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '21'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
 
     - name: Build and check
       run: |
@@ -114,6 +126,9 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: '21'
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
 
     - name: Build and check
       run: |

--- a/.github/workflows/generate-v3.yml
+++ b/.github/workflows/generate-v3.yml
@@ -33,6 +33,9 @@ jobs:
         distribution: 'adopt'
         java-version: 17
 
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v5
+
     - name: Install NDK
       run: |
         sudo ${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager --install "ndk;20.0.5594570"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,6 +33,9 @@ jobs:
           distribution: 'adopt'
           java-version: '17'
 
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v5
+
       - name: Run Android Lint
         run: |
           ./gradlew :ApiDemos:kotlin-app:lintDebug


### PR DESCRIPTION
This PR replaces the wrapper-validation by setup-gradle, which already [validates the wrapper](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md), and introduces a nice table after sniffing the Gradle task with some extra-info.

<img width="908" height="790" alt="image" src="https://github.com/user-attachments/assets/3b934371-7693-4a96-91b9-2eec980a3bb7" />
