### PR TITLE
fix(idx): remove incorrect default subdir causing build errors

### DIFF
--- a/open-in-idx-template/idx-template.json
+++ b/open-in-idx-template/idx-template.json
@@ -19,8 +19,7 @@
       {
         "id": "subdir",
         "name": "Project Subfolder",
-        "type": "text",
-        "default": "tutorials/java/MapWithMarker/"
+        "type": "text"
       },
       {
         "id": "launchactivity",


### PR DESCRIPTION
Fixes #2354

Removes the incorrect default `subdir` value in `open-in-idx-template/idx-template.json` which caused build errors when generating a workspace in IDX/Firebase Studio because it incorrectly scoped the project to a single tutorial module instead of the root folder.