### PR TITLE
build: update GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,16 +32,16 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '21'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build and check
       run: |
@@ -55,16 +55,16 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '21'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build and check
       run: ./gradlew :WearOS:Wearable:assembleDebug
@@ -74,16 +74,16 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '21'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build and check
       run: ./gradlew :FireMarkers:app:assembleDebug
@@ -93,16 +93,16 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '21'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build and check
       run: |
@@ -118,16 +118,16 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: set up Java 21
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: '21'
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Build and check
       run: |
@@ -143,11 +143,11 @@ jobs:
       - build-Snippets
       - build-tutorials
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: set up Java 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
       
       - name: Run Unit Tests

--- a/.github/workflows/generate-v3.yml
+++ b/.github/workflows/generate-v3.yml
@@ -25,16 +25,16 @@ jobs:
     timeout-minutes: 45
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: set up JDK 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
-        distribution: 'adopt'
+        distribution: 'temurin'
         java-version: 17
 
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v5
+      uses: gradle/actions/setup-gradle@v6
 
     - name: Install NDK
       run: |
@@ -48,7 +48,7 @@ jobs:
         echo "files-changed=$(git status -s | wc -l)" >> $GITHUB_OUTPUT
 
     - name: PR Changes
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@v8
       if: steps.gradlew-generate-v3.outputs.files-changed > 0
       with:
         token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,16 +25,16 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
-          distribution: 'adopt'
+          distribution: 'temurin'
           java-version: '21'
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
@@ -42,7 +42,7 @@ jobs:
         run: python3 scripts/update_docs_versions.py --check
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v5
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run Android Lint
         run: |
@@ -59,67 +59,67 @@ jobs:
           ./gradlew :FireMarkers:app:lintDebug
 
       - name: Upload SARIF for ApiDemos:kotlin-app
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ApiDemos/project/kotlin-app/build/reports/lint-results-debug.sarif
           category: ApiDemos-kotlin-app
 
       - name: Upload SARIF for ApiDemos:java-app
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ApiDemos/project/java-app/build/reports/lint-results-debug.sarif
           category: ApiDemos-java-app
 
       - name: Upload SARIF for ApiDemos:common-ui
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ApiDemos/project/common-ui/build/reports/lint-results-debug.sarif
           category: ApiDemos-common-ui
 
       - name: Upload SARIF for snippets:app
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snippets/app/build/reports/lint-results-debug.sarif
           category: snippets-app
 
       - name: Upload SARIF for snippets:app-utils
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snippets/app-utils/build/reports/lint-results-debug.sarif
           category: snippets-app-utils
 
       - name: Upload SARIF for snippets:app-utils-ktx
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snippets/app-utils-ktx/build/reports/lint-results-debug.sarif
           category: snippets-app-utils-ktx
 
       - name: Upload SARIF for snippets:app-places-ktx
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snippets/app-places-ktx/build/reports/lint-results-debug.sarif
           category: snippets-app-places-ktx
 
       - name: Upload SARIF for snippets:app-ktx
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snippets/app-ktx/build/reports/lint-results-debug.sarif
           category: snippets-app-ktx
 
       - name: Upload SARIF for snippets:app-compose
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: snippets/app-compose/build/reports/lint-results-debug.sarif
           category: snippets-app-compose
 
       - name: Upload SARIF for WearOS:Wearable
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: WearOS/Wearable/build/reports/lint-results-debug.sarif
           category: WearOS-Wearable
 
       - name: Upload SARIF for FireMarkers:app
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: FireMarkers/app/build/reports/lint-results-debug.sarif
           category: FireMarkers-app

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -27,7 +27,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.SYNCED_GITHUB_TOKEN_REPO }}


### PR DESCRIPTION
### Description
This PR updates all GitHub Action workflows to their latest stable major versions as of May 2026. These updates ensure compatibility with the Node.js 24 runtime and modern CI/CD standards.

### Changes
- actions/checkout: Upgraded to v6.
- actions/setup-java: Upgraded to v5. Migrated distribution: 'adopt' to 'temurin' (AdoptOpenJDK is deprecated).
- actions/setup-python: Upgraded to v6.
- gradle/actions/setup-gradle: Upgraded to v6.
- github/codeql-action/upload-sarif: Upgraded to v4.
- peter-evans/create-pull-request: Upgraded to v8.
- googleapis/release-please-action: Upgraded to v5.

### Integrity & Path Validation
- Verified that all SARIF report paths in lint.yml correctly map to the subproject build directories defined in settings.gradle.kts.
- Confirmed that no upload-artifact name collisions exist (v7 immutable backend requirement).
- Surgical updates were applied to maintain existing build and test logic.